### PR TITLE
Return a way to deconstruct the Socket listeners from useEffect

### DIFF
--- a/scripts/Content.jsx
+++ b/scripts/Content.jsx
@@ -10,11 +10,16 @@ export function Content() {
     
     function getNewAddresses() {
         React.useEffect(() => {
-            Socket.on('addresses received', (data) => {
-                console.log("Received addresses from server: " + data['allAddresses']);
-                setAddresses(data['allAddresses']);
-            })
+            Socket.on('addresses received', updateAddresses);
+            return () => {
+                Socket.off('addresses received', updateAddresses);
+            }
         });
+    }
+    
+    function updateAddresses(data) {
+        console.log("Received addresses from server: " + data['allAddresses']);
+        setAddresses(data['allAddresses']);
     }
     
     getNewAddresses();


### PR DESCRIPTION
Since `useEffect()` is called every time the component updates, many duplicate `Socket.on('addresses received', ...)` listeners were created, resulting in `setAddresses()` being called multiple times per event. Eventually, this may cause some slowdown, and as the program becomes more complex, the issue is compounded. Luckily, the return value of `useEffect()` is used like a deconstructor and is called every update before the rest of `useEffect()` executes. By destroying/disabling the old listeners at this point, we avoid creating duplicates.